### PR TITLE
chore: migrate old name 'resume-astro' to 'resume'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "resume-astro",
+  "name": "resume",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "resume-astro",
+      "name": "resume",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "resume-astro",
+  "name": "resume",
   "type": "module",
   "version": "0.0.1",
   "scripts": {


### PR DESCRIPTION
## What

Resolve #1 

As title, renamed the settings which are related to the old repository name.