### PR TITLE
chore: enable typescript-lsp plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "enabledPlugins": {
     "commit-commands@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary

Enable the `typescript-lsp` Claude Code plugin for enhanced TypeScript language server support during development.

## Changes

- Added `typescript-lsp@claude-plugins-official` to enabled plugins in `.claude/settings.json`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Content update (profile data, text changes)
- [ ] Style / UI change
- [ ] Refactor (no functional change)
- [x] Build / CI configuration
- [ ] Dependencies update
- [ ] Documentation