### PR TITLE
test: hide Next.js dev indicator in screenshots

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Hide the dev indicator when HIDE_DEV_INDICATORS=1 (used by visual regression
+  // tests so the floating icon doesn't appear in screenshots).
+  devIndicators:
+    process.env.HIDE_DEV_INDICATORS === '1'
+      ? false
+      : { position: 'bottom-left' },
 };
 
 export default nextConfig;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -81,5 +81,8 @@ export default defineConfig({
     command: 'npm run dev',
     url: 'http://localhost:4321',
     reuseExistingServer: !process.env.CI,
+    env: {
+      HIDE_DEV_INDICATORS: '1',
+    },
   },
 });


### PR DESCRIPTION
## Summary

Hide the Next.js dev indicator (the floating icon that appears at the bottom of the page in `next dev`) during Playwright visual regression runs, so it does not bleed into screenshots and cause spurious diffs.

## Changes

- `next.config.ts`: set `devIndicators: false` when `HIDE_DEV_INDICATORS=1`; otherwise keep the default `{ position: 'bottom-left' }` so normal `npm run dev` is unaffected.
- `playwright.config.ts`: pass `HIDE_DEV_INDICATORS=1` via `webServer.env` so the dev server Playwright spawns has the indicator disabled.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Content update (profile data, text changes)
- [ ] Style / UI change
- [ ] Refactor (no functional change)
- [x] Build / CI configuration
- [ ] Dependencies update
- [ ] Documentation

## Notes

`reuseExistingServer: !process.env.CI` means a locally-running `npm run dev` will be reused without the env var applied. Restart the dev server (or run with `CI=1`) before `npm run test` locally if the indicator shows up in screenshots.