### PR TITLE
docs(profile): bump experience to 8+ years

### DIFF
--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -100,7 +100,7 @@ export const profile: Profile = {
       'Chinese:native',
     ],
     about:
-      'Full Stack Engineer with 7+ years of experience in frontend, backend, and Android development. Proficient in modern architectures and frameworks including TypeScript, React, Node.js, Kotlin, Kubernetes, and cloud platforms (AWS, GCP). Focused on writing clean, maintainable code and improving developer experience.',
+      'Full Stack Engineer with 8+ years of experience in frontend, backend, and Android development. Proficient in modern architectures and frameworks including TypeScript, React, Node.js, Kotlin, Kubernetes, and cloud platforms (AWS, GCP). Focused on writing clean, maintainable code and improving developer experience.',
   },
   contact: {
     city: 'Tokyo',


### PR DESCRIPTION
## Summary

Update the profile summary from "7+ years of experience" to "8+ years".

## Changes

- `src/data/profile.ts`: bump experience count in `summary.about`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Content update (profile data, text changes)
- [ ] Style / UI change
- [ ] Refactor (no functional change)
- [ ] Build / CI configuration
- [ ] Dependencies update
- [ ] Documentation