### PR TITLE
chore(deps): sync lockfile with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "resume-next",
-      "version": "0.1.0",
+      "name": "resume",
+      "version": "0.0.1",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-brands-svg-icons": "^6.5.1",
@@ -23,18 +23,18 @@
         "@commitlint/cli": "^20.4.2",
         "@commitlint/config-conventional": "^20.4.2",
         "@playwright/test": "^1.53.0",
-        "@types/node": "^20",
-        "@types/react": "^19",
-        "@types/react-dom": "^19",
+        "@types/node": "^20.19.35",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "autoprefixer": "^10.4.19",
-        "eslint": "^9",
+        "eslint": "^9.39.3",
         "eslint-config-next": "16.1.6",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
         "postcss": "^8.4.38",
         "prettier": "3.2.4",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {


### PR DESCRIPTION
## Summary

Regenerate `package-lock.json` so it matches the current `package.json`. No source code or runtime behavior changes.

## Changes

- Project name: `resume-next` → `resume`
- Project version: `0.1.0` → `0.0.1`
- Tightened dev-dependency version pins to match installed: `@types/node`, `@types/react`, `@types/react-dom`, `eslint`, `typescript`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Content update (profile data, text changes)
- [ ] Style / UI change
- [ ] Refactor (no functional change)
- [ ] Build / CI configuration
- [x] Dependencies update
- [ ] Documentation