### PR TITLE
refactor(layout): unify printable width via rem scaling

### DIFF
--- a/src/components/PrintableLayout.module.css
+++ b/src/components/PrintableLayout.module.css
@@ -8,9 +8,7 @@
   --print-padding: 0.4in;
   --page-padding: calc(var(--print-padding) / var(--print-rem-base) * 1rem);
 
-  width: calc(
-    var(--print-paper-width) * var(--screen-rem-base) / var(--print-rem-base)
-  );
+  width: calc(var(--print-paper-width) / var(--print-rem-base) * 1rem);
   padding: var(--page-padding);
   margin: 0 auto;
 }
@@ -29,8 +27,6 @@
   }
 
   .printableLayout {
-    /* The screen-scaled width overflows A4; let @page control the layout size. */
-    width: unset;
     print-color-adjust: exact;
   }
 }


### PR DESCRIPTION
## Summary

Replace the screen-only mm-based width calculation and its print-time `width: unset` override with a single rem-based formula that scales correctly under both screen (rem=16px) and `@media print` (rem=14px). Same conversion trick already used for `--page-padding` on the line above.

## Changes

- `src/components/PrintableLayout.module.css`:
  - `width` now `calc(var(--print-paper-width) / var(--print-rem-base) * 1rem)` — unitless ratio × `1rem` resolves to 240mm on screen and 210mm on print, matching `@page A4`
  - Removed the `@media print` `width: unset` override (no longer needed)
  - Removed the now-stale comment about the screen-scaled width overflowing A4

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Content update (profile data, text changes)
- [ ] Style / UI change
- [x] Refactor (no functional change)
- [ ] Build / CI configuration
- [ ] Dependencies update
- [ ] Documentation

## How to Test

- `npm run dev` → load `/`, confirm screen layout width unchanged
- Browser print preview → page fits A4 with no horizontal overflow
- `npm run test` → visual regression should pass without snapshot updates