### PR TITLE
fix(layout): apply per-page print margins via @page

### DIFF
--- a/src/components/PrintableLayout.module.css
+++ b/src/components/PrintableLayout.module.css
@@ -21,12 +21,17 @@
     font-size: calc(var(--print-rem-base) / var(--screen-rem-base) * 100%);
   }
 
+  /* Page margins must live on @page, not as container padding: container
+    padding applies once at the start/end of the whole document, so content on
+    intermediate page boundaries would run flush to the paper edge. */
   @page {
     size: A4 portrait;
-    margin: 0;
+    margin: 0.4in;
   }
 
   .printableLayout {
+    width: auto;
+    padding: 0;
     print-color-adjust: exact;
   }
 }


### PR DESCRIPTION
## Summary

Printing produced 2 pages with content running flush to the paper edge at the bottom of page 1 and the top of page 2. The page spacing lived as padding on the layout container, which applies only once at the start and end of the whole document — intermediate page boundaries got zero margin, so printers would clip the content there.

This moves the print spacing to `@page { margin: 0.4in }` so every page gets proper margins, and zeroes the container's fixed width/padding in print since the printable area is now narrower than full A4. Screen layout is unchanged.

Verified by generating a print PDF via Playwright (clean margins on both pages, breaks fall between lines) and running the visual regression test (passes, screen render unchanged).

Note: with non-zero `@page` margins, browsers now render their default headers/footers (date/title, URL/page number) in the margin area when printing manually — these can be disabled via the print dialog's "Headers and footers" checkbox. The previous `margin: 0` only hid them as a side effect.

## Changes

- Move print page spacing from container padding to `@page { margin: 0.4in }` in `PrintableLayout.module.css`
- Set `width: auto` and `padding: 0` on `.printableLayout` under `@media print` to fit the reduced printable area

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Content update (profile data, text changes)
- [ ] Style / UI change
- [ ] Refactor (no functional change)
- [ ] Build / CI configuration
- [ ] Dependencies update
- [ ] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)